### PR TITLE
Exclude points outside of ROI

### DIFF
--- a/ftc/fixtures/grain1_region_hole.json
+++ b/ftc/fixtures/grain1_region_hole.json
@@ -1,0 +1,45 @@
+[
+  {
+    "model": "ftc.region",
+    "pk": 11,
+    "fields": {
+      "grain": 1
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 15,
+    "fields": {
+      "region": 11,
+      "x": 70,
+      "y": 80
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 16,
+    "fields": {
+      "region": 11,
+      "x": 80,
+      "y": 70
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 17,
+    "fields": {
+      "region": 11,
+      "x": 80,
+      "y": 70
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 18,
+    "fields": {
+      "region": 11,
+      "x": 70,
+      "y": 70
+    }
+  }
+]

--- a/ftc/fixtures/grain_with_negative_region.json
+++ b/ftc/fixtures/grain_with_negative_region.json
@@ -1,0 +1,120 @@
+[
+  {
+    "model": "ftc.grain",
+    "pk": 7,
+    "fields": {
+      "sample": 1,
+      "index": 7,
+      "image_width": 200,
+      "image_height": 200,
+      "scale_x": null,
+      "scale_y": null,
+      "stage_x": null,
+      "stage_y": null,
+      "mica_stage_x": null,
+      "mica_stage_y": null,
+      "shift_x": 0,
+      "shift_y": 0,
+      "mica_transform_matrix": null
+    }
+  },
+  {
+    "model": "ftc.region",
+    "pk": 70,
+    "fields": {
+      "grain": 7
+    }
+  },
+  {
+    "model": "ftc.region",
+    "pk": 71,
+    "fields": {
+      "grain": 7
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 70,
+    "fields": {
+      "region": 70,
+      "x": 1,
+      "y": 199
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 71,
+    "fields": {
+      "region": 70,
+      "x": 199,
+      "y": 199
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 72,
+    "fields": {
+      "region": 70,
+      "x": 199,
+      "y": 1
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 73,
+    "fields": {
+      "region": 70,
+      "x": 1,
+      "y": 1
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 74,
+    "fields": {
+      "region": 71,
+      "x": 90,
+      "y": 110
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 75,
+    "fields": {
+      "region": 71,
+      "x": 110,
+      "y": 110
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 76,
+    "fields": {
+      "region": 71,
+      "x": 110,
+      "y": 90
+    }
+  },
+  {
+    "model": "ftc.vertex",
+    "pk": 77,
+    "fields": {
+      "region": 71,
+      "x": 90,
+      "y": 90
+    }
+  },
+  {
+    "model": "ftc.image",
+    "pk": 71,
+    "fields": {
+      "grain": 7,
+      "format": "J",
+      "ft_type": "S",
+      "index": 1,
+      "data": "/9j/4AAQSkZJRgABAQEBLAEsAAD//gATQ3JlYXRlZCB3aXRoIEdJTVD/4gKwSUNDX1BST0ZJTEUAAQEAAAKgbGNtcwQwAABtbnRyUkdCIFhZWiAH5QACABYAEAAjAAlhY3NwQVBQTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9tYAAQAAAADTLWxjbXMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1kZXNjAAABIAAAAEBjcHJ0AAABYAAAADZ3dHB0AAABmAAAABRjaGFkAAABrAAAACxyWFlaAAAB2AAAABRiWFlaAAAB7AAAABRnWFlaAAACAAAAABRyVFJDAAACFAAAACBnVFJDAAACFAAAACBiVFJDAAACFAAAACBjaHJtAAACNAAAACRkbW5kAAACWAAAACRkbWRkAAACfAAAACRtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACQAAAAcAEcASQBNAFAAIABiAHUAaQBsAHQALQBpAG4AIABzAFIARwBCbWx1YwAAAAAAAAABAAAADGVuVVMAAAAaAAAAHABQAHUAYgBsAGkAYwAgAEQAbwBtAGEAaQBuAABYWVogAAAAAAAA9tYAAQAAAADTLXNmMzIAAAAAAAEMQgAABd7///MlAAAHkwAA/ZD///uh///9ogAAA9wAAMBuWFlaIAAAAAAAAG+gAAA49QAAA5BYWVogAAAAAAAAJJ8AAA+EAAC2xFhZWiAAAAAAAABilwAAt4cAABjZcGFyYQAAAAAAAwAAAAJmZgAA8qcAAA1ZAAAT0AAACltjaHJtAAAAAAADAAAAAKPXAABUfAAATM0AAJmaAAAmZwAAD1xtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAEcASQBNAFBtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEL/2wBDACAWGBwYFCAcGhwkIiAmMFA0MCwsMGJGSjpQdGZ6eHJmcG6AkLicgIiuim5woNqirr7EztDOfJri8uDI8LjKzsb/2wBDASIkJDAqMF40NF7GhHCExsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsb/wgARCADIAMgDAREAAhEBAxEB/8QAGQABAQEBAQEAAAAAAAAAAAAAAAECBAMF/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEAMQAAAB+gAAAACAAAoAAAAAAABAAQFABQAAAAAAQAgICgoBQAAAAAQAhCEIaKUoBQAAAACAhCEB88+gUpSgFAAAAICEICnMYO0yQpooKAAAAQGSA0ZKch2kMkNFKUAAAAgMgpSkOQ7CEMkNlBQAAACAAoIcZ2kBkyaNAoAAAAAABk5TrAMmSmwUAAAAAAA8jzOggIZKbKAAAAAAADwB6ghCGjRQAAAAAAAeAPYhCENlKAAAAAAADjOk0QhkpopQAAAAAAAcB3AhkhopQUAAAAgAAOM7AZIUoKCgAAAgBAQyc51mQaKQhSlAAABAZMgp5Hme4NlBDJTZQAAAQhgyaKeIPYAFMg0aKAAACAyZIUGjRCGSFNGgUAAAAgIZBSgAgKUFAAAAAIAQAAAFBQAAAAACAAgAKAUAAAAAAAEAAABQAAAAAAAACAAoAAAB/8QAIRAAAQMDBAMAAAAAAAAAAAAAAwEyQAACIRESMTMiYHD/2gAIAQEAAQUC9wXFXKt10fsW7tjXJuRE2omTSLO2QJ8deASCMCyOVgmRzMEyOek4jr5GkDySPcuA8RyNE2ORg2x9NaRNPhX/xAAUEQEAAAAAAAAAAAAAAAAAAACQ/9oACAEDAQE/ARx//8QAFBEBAAAAAAAAAAAAAAAAAAAAkP/aAAgBAgEBPwEcf//EABsQAQEAAQUAAAAAAAAAAAAAAAFAUAARYGFw/9oACAEBAAY/AuYlHWgJ9q2laWhyZQGSfbv/xAAgEAADAAEFAAMBAAAAAAAAAAAAAREQICEwMUBRYGGh/9oACAEBAAE/Ifq1xYXzwlY2l1RdeWD2VZv+f+ibJ0Qa8LxMoXBFvfxlrC5mThrELxPoW6E8LxPHK3fuhjF4mgLNJi8XYdOpeJo+tLxNf0YsVZeF49qvjQyeN9G95fjpSDnc/kpdS5Gy52uJFLhZYxcbHhY7hdpCYpS4XI0TLRIxCRaHiCXNCE1wn2v/2gAMAwEAAgADAAAAEAAAAAJJJAAAAAAAABIBIBIAAAAAABIIJBBIAAAAABIJBIIBIAAAAAIJBIAABIAAAAIJAAIJIBAAAABBBJJJJBIAAAAIAJBAJBAIAAAAIBABBBABAAAAAAAAJIIIIAAAAAAAABABAAAAAAAABJAIBAAAAAAAABAAAIAAAAAAAAIIAJAAAAAAAAJJBBBAAAABJJAIBIAIAAABIIIIJIABAAAAIBIBBBJJAAAABIJJBAIIJAAAAIAIABJIAIAAAAIBJJIIAIAAAAAJBAAAIIAAAAAAJIJJAIAAAAAAABJAJIAAAAAAAAAJJAAAAB//xAAUEQEAAAAAAAAAAAAAAAAAAACQ/9oACAEDAQE/EBx//8QAFBEBAAAAAAAAAAAAAAAAAAAAkP/aAAgBAgEBPxAcf//EACIQAQEBAAEEAgIDAAAAAAAAAAEAERAhMDFAQVEgUGFxof/aAAgBAQABPxD9Jtttvq7bbbDbb6SyzNk+SEQYYe+yyywbJaYFsQLoPuKHfqGGGO6zLLGpDdAI2HhoR0JPDg8Qwx3GUuxAjVKD9R08CPwLgnB4ZR3GEQOXw/hUhKUdzIPweN/iZt+czlheGcejsf4gtzo9HLw8uJ6O8PqUlfPXhbZvLiej/nv8szwz5jHojt+b5h8TMyx1YekCdgyvATPB6xj0mk+KGGcLwIER39liZdD6b54WUGwcnc23g3Zn1HFuq4sDYOGWUdpbCbq2Scf1dDfNqGUMspcTttxw26/6bb+uOPxEYwNYx2k4HF1LrIA0YgGBwkkLrGuAO4kxpA/Bk4EDv5Z+eWellllllnrZZ+k//9k=",
+      "light_path": "T",
+      "focus": 50000
+    }
+  }
+]

--- a/ftc/fixtures/results.json
+++ b/ftc/fixtures/results.json
@@ -5,7 +5,7 @@
         "fields": {
             "grain": 1,
             "ft_type": "S",
-            "worker": 101,
+            "worker": 102,
             "result": 3,
             "create_date": "2023-01-01T00:00:00Z"
         }
@@ -27,7 +27,7 @@
             "result": 1,
             "category": "track",
             "x_pixels": 40,
-            "y_pixels": 362
+            "y_pixels": 70
         }
     },
     {
@@ -36,8 +36,8 @@
         "fields": {
             "result": 1,
             "category": "track",
-            "x_pixels": 201,
-            "y_pixels": 160
+            "x_pixels": 71,
+            "y_pixels": 75
         }
     },
     {

--- a/ftc/fixtures/test_user.json
+++ b/ftc/fixtures/test_user.json
@@ -1,0 +1,30 @@
+[
+    {
+        "model": "auth.user",
+        "pk": 104,
+        "fields": {
+            "password": "pbkdf2_sha256$390000$PoREgulL1Tu3bXqP947KZ5$w6bPXzASAfqFkKbt5ioYPvjM7rWMgDHjt5yP8Cy9MNw=",
+            "last_login": null,
+            "is_superuser": false,
+            "username": "tester",
+            "first_name": "",
+            "last_name": "",
+            "email": "tester@test.com",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-03-03T09:39:19.689Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "account.emailaddress",
+        "pk": 103,
+        "fields": {
+            "user": 104,
+            "email": "tester@test.com",
+            "verified": true,
+            "primary": true
+        }
+    }
+]

--- a/ftc/static/counting/script/geochron.js
+++ b/ftc/static/counting/script/geochron.js
@@ -779,13 +779,14 @@ function grain_view(options) {
             }
             return inside;
         };
-        function point_in_any_polygon(x, y, vss) {
+        function point_in_odd_number_of_polygons(x, y, vss) {
+            var count = 0;
             for (var i =0; i !== vss.length; ++i) {
                 if (point_in_polygon(x, y, vss[i])) {
-                    return true;
+                    count += 1;
                 }
             }
-            return false;
+            return (count % 2) === 1;
         }
         function add_current_layer() {
             if (layerRendered < imageOverlayers.length) {
@@ -821,7 +822,7 @@ function grain_view(options) {
                 refresh();
             },
             pointInRois: function(x, y) {
-                return point_in_any_polygon(x, y, rois);
+                return point_in_odd_number_of_polygons(x, y, rois);
             },
             rois_layer: rois_layer
         };

--- a/ftc/static/counting/script/geochron.js
+++ b/ftc/static/counting/script/geochron.js
@@ -1062,11 +1062,11 @@ function grain_view(options) {
         }
         forEachCreateMarker(grain_info.points, function(create, point) {
             if (point_filter(point)) {
-                create(
-                    [(height - point.y_pixels) / width, point.x_pixels / width],
-                    point.category,
-                    point.comment
-                );
+                var lat = (height - point.y_pixels) / width;
+                var lng = point.x_pixels / width;
+                if (zStack.pointInRois(lat, lng)) {
+                    create([lat, lng], point.category, point.comment);
+                }
             }
         });
         undo.reset();

--- a/ftc/test_selenium.py
+++ b/ftc/test_selenium.py
@@ -1668,7 +1668,30 @@ class GrainsWithDifferentlySizedRegions(SeleniumTests):
         assert self.driver.current_url.endswith('/6/')
         self.assert_all_markers_are_close_to_edge(counting)
 
-class GrainsWithDifferentlySizedRegions(SeleniumTests):
+class RegionWithHole(SeleniumTests):
+    fixtures = [
+        'essential.json',
+        'users.json',
+        'test_user.json',
+        'projects.json',
+        'samples.json',
+        'grain_with_negative_region.json',
+    ]
+
+    def test_cannot_count_tracks_in_hole(self):
+        counting = self.sign_in(self.test_user).go_start_counting().check()
+        # start counting tracks
+        counting.check_count("000")
+        counting.click_at(0.1, 0.1)
+        counting.check_count("001")
+        counting.click_at(0.5, 0.5)
+        # this one is inside both boundaries so is in the hole
+        counting.check_count("001")
+        counting.click_at(0.9, 0.9)
+        counting.check_count("002")
+
+
+class PublicPageResults(SeleniumTests):
     fixtures = [
         'essential.json',
         'grain_with_images.json',

--- a/ftc/views.py
+++ b/ftc/views.py
@@ -866,7 +866,7 @@ def add_grain_info_markers(info, grain, ft_type, worker):
         objects = objects.filter(worker=worker)
     save = objects.order_by('result').first()
     if save:
-        info['marker_latlngs'] = save.get_latlngs()
+        info['marker_latlngs'] = save.get_latlngs_within_roi()
         info['points'] = save.points()
 
 def get_grain_info(user, pk, ft_type, **kwargs):


### PR DESCRIPTION
Not super happy with this; there's a test to show that you can't add a point within a negative ROI, but there is no test that points outside of the ROI aren't shown in the public view. I have also taken a completely different approach with the old latlngs stuff and the newer pixel based stuff.

I'll have a think about that.

But if you want to play with this, here it is.