### PR TITLE
guest user can be offered the same grain multiple times

### DIFF
--- a/ftc/fixtures/samples.json
+++ b/ftc/fixtures/samples.json
@@ -8,6 +8,7 @@
             "sample_property": "T",
             "priority": 5,
             "min_contributor_num": 10,
+            "public": true,
             "completed": false
         }
     },
@@ -20,6 +21,7 @@
             "sample_property": "T",
             "priority": 10,
             "min_contributor_num": 4,
+            "public": true,
             "completed": false
         }
     }

--- a/ftc/grain_uinfo.py
+++ b/ftc/grain_uinfo.py
@@ -36,7 +36,7 @@ def choose_working_grain(request, ft_type):
         grain=OuterRef('pk'),
         ft_type=ft_type
     )))
-    # Grains with images, in non-completed samples in open projects
+    # Grains with images, in non-completed samples in open, public projects
     basic_query = Grain.objects.annotate(
         backref_count=backref_count
     ).filter(

--- a/ftc/grain_uinfo.py
+++ b/ftc/grain_uinfo.py
@@ -36,8 +36,19 @@ def choose_working_grain(request, ft_type):
         grain=OuterRef('pk'),
         ft_type=ft_type
     )))
+    # Grains with images, in non-completed samples in open projects
+    basic_query = Grain.objects.annotate(
+        backref_count=backref_count
+    ).filter(
+        has_backref_image,
+        sample__in_project__closed=False,
+        sample__completed=False,
+        sample__public=True,
+    )
     if request.user.username == 'guest':
-        grain_is_suitable = has_backref_image
+        available_to_count = basic_query.order_by(
+            '?'
+        )
     else:
         # Result objects produced by this user
         has_backref_user = FissionTrackNumbering.objects.filter(
@@ -46,23 +57,18 @@ def choose_working_grain(request, ft_type):
             ft_type=ft_type,
             result__gte=0
         )
-        grain_is_suitable = has_backref_image & ~Q(Exists(has_backref_user))
-    # Grains without results from this user, and with more results needed
-    # Ordered by priority of project then priority of sample
-    # A random one of these top priority samples will be first
-    available_to_count = Grain.objects.values('id').annotate(
-        backref_count=backref_count
-    ).filter(
-        grain_is_suitable,
-        sample__in_project__closed=False,
-        sample__completed=False,
-        sample__min_contributor_num__gte=F('backref_count')
-    ).order_by(
-        '-sample__in_project__priority',
-        '-sample__priority',
-        '?'
-    )
-    chosen = available_to_count.first()
+        # Only grains that don't have enough (non-guest) results anyway.
+        # Choosing at random from those projects at the highest priority
+        # and within that those samples at the highest priority.
+        available_to_count = basic_query.filter(
+            ~Q(Exists(has_backref_user)),
+            sample__min_contributor_num__gte=F('backref_count'),
+        ).order_by(
+            '-sample__in_project__priority',
+            '-sample__priority',
+            '?'
+        )
+    chosen = available_to_count.values('id').first()
     if chosen is None:
         return None
     chosen_id = chosen['id']

--- a/ftc/grain_uinfo.py
+++ b/ftc/grain_uinfo.py
@@ -31,25 +31,29 @@ def choose_working_grain(request, ft_type):
         Q(results__result__gte=0)
         & ~Q(results__worker__username='guest')
     )
-    # Result objects produced by this user
-    has_backref_user = FissionTrackNumbering.objects.filter(
-        grain=OuterRef('pk'),
-        worker=request.user,
-        ft_type=ft_type,
-        result__gte=0
-    )
-    has_backref_image = Image.objects.filter(
+    # Only include grains with images
+    has_backref_image = Q(Exists(Image.objects.filter(
         grain=OuterRef('pk'),
         ft_type=ft_type
-    )
+    )))
+    if request.user.username == 'guest':
+        grain_is_suitable = has_backref_image
+    else:
+        # Result objects produced by this user
+        has_backref_user = FissionTrackNumbering.objects.filter(
+            grain=OuterRef('pk'),
+            worker=request.user,
+            ft_type=ft_type,
+            result__gte=0
+        )
+        grain_is_suitable = has_backref_image & ~Q(Exists(has_backref_user))
     # Grains without results from this user, and with more results needed
     # Ordered by priority of project then priority of sample
     # A random one of these top priority samples will be first
     available_to_count = Grain.objects.values('id').annotate(
         backref_count=backref_count
     ).filter(
-        ~Q(Exists(has_backref_user)),
-        Q(Exists(has_backref_image)),
+        grain_is_suitable,
         sample__in_project__closed=False,
         sample__completed=False,
         sample__min_contributor_num__gte=F('backref_count')
@@ -58,7 +62,6 @@ def choose_working_grain(request, ft_type):
         '-sample__priority',
         '?'
     )
-    s = str(available_to_count.query)
     chosen = available_to_count.first()
     if chosen is None:
         return None

--- a/ftc/test_integration.py
+++ b/ftc/test_integration.py
@@ -105,6 +105,7 @@ class CountingCase(GahCase):
       self.count_grain(j["sample_id"], j["grain_num"], count)
 
   def get_total_track_count(self):
+    """Get a pair of track counts (including guest counts, excluding guest counts)."""
     r = self.client.post(
       reverse('getTableData'),
       { 'client_response': [
@@ -115,6 +116,7 @@ class CountingCase(GahCase):
     self.assertEqual(r.status_code, 200)
     j = json.loads(r.content)
     total = 0
+    total_exc_guest = 0
     for [project, sample, index, ft_type, track_count, user, datetime, area] in j['aaData']:
       total += track_count
     return total
@@ -144,14 +146,15 @@ class TestGuestCounts(CountingCase):
       self.count_grain(1, 1, ac)
     self.logout()
     self.login_admin()
-    total = self.get_total_track_count()
-    # should get the results from sample 1 which is owned by admin
-    self.assertEqual(total, base_admin + sum(acounts))
+    # get the results from sample 1 which is owned by admin
+    total_sample1 = self.get_total_track_count()
     self.logout()
     self.login_super()
-    total = self.get_total_track_count()
     # should get the results from all samples
-    self.assertEqual(total, base_super + guest_count * sum(scounts) + sum(acounts))
+    total_sample2 = self.get_total_track_count()
+    self.assertEqual(total_sample2, base_super + guest_count * sum(scounts) + sum(acounts))
+    self.assertLess(base_admin + sum(acounts), total_sample1)
+    self.assertLess(total_sample1, base_admin + sum(acounts) + guest_count * sum(scounts))
 
 
 class TestCountJsonDownload(CountingCase):

--- a/ftc/test_integration.py
+++ b/ftc/test_integration.py
@@ -1,5 +1,5 @@
 from django.test import TestCase, tag
-from django.urls import reverse
+from django.urls import resolve, reverse
 from django.contrib.auth.models import User, Group
 
 import csv
@@ -25,6 +25,15 @@ def gen_latlngs(n):
     r.append(gen_latlng())
   return r
 
+grain_info_re = re.compile(r"grain_info:\s*JSON.parse\('(.*)'\)")
+
+def grain_info_from_response(response):
+  """Get a grian info from counting.html, public.html or tutorial.html."""
+  content = response.content.decode('utf-8')
+  grain_info_json = grain_info_re.search(content).group(1)
+  grain_info_json = grain_info_json.replace("\\u0022", '"')
+  j = json.loads(grain_info_json)
+  return j
 
 @tag('integration')
 class GahCase(TestCase):
@@ -38,13 +47,13 @@ class GahCase(TestCase):
     return r
 
   def login_admin(self):
-    self.login('admin', 'admin_password')
+    return self.login('admin', 'admin_password')
 
   def login_super(self):
-    self.login('super', 'super_password')
+    return self.login('super', 'super_password')
 
   def login_counter(self):
-    self.login('counter', 'counter_password')
+    return self.login('counter', 'counter_password')
 
   def logout(self):
     self.client.post(reverse('logout'))
@@ -83,9 +92,17 @@ class CountingCase(GahCase):
   def perform_guest_count(self, grain_counts):
     self.client.get(reverse('guest_counting'))
     self.complete_tutorial()
-    for ((sample, grain), count) in grain_counts.items():
-      self.count_grain(sample, grain, count)
-    self.logout()
+    grain_ids_seen = set()
+    for count in grain_counts:
+      res = self.client.get(reverse('guest_counting'))
+      self.assertEqual(res.status_code, 302)
+      resolved = resolve(res.url)
+      grain_ids_seen.add(resolved.kwargs["pk"])
+      self.assertEqual(resolved.url_name, 'count')
+      red = self.client.get(res.url)
+      j = grain_info_from_response(red)
+      self.assertIsNotNone(j, "No grains for counting")
+      self.count_grain(j["sample_id"], j["grain_num"], count)
 
   def get_total_track_count(self):
     r = self.client.post(
@@ -116,20 +133,25 @@ class TestGuestCounts(CountingCase):
     self.login_super()
     base_super = self.get_total_track_count()
     self.logout()
-    s1count = 5
-    s2count = 6
+    # Do some counting as guest
+    scounts = [5, 6]
     guest_count = 5
     for i in range(guest_count):
-      self.perform_guest_count({ (1, 1): s1count, (2, 1): s2count })
+      self.perform_guest_count(scounts)
+    # count admin's own
+    acounts = [7, 6, 4]
+    for ac in acounts:
+      self.count_grain(1, 1, ac)
+    self.logout()
     self.login_admin()
     total = self.get_total_track_count()
     # should get the results from sample 1 which is owned by admin
-    self.assertEqual(total, base_admin + guest_count * s1count)
+    self.assertEqual(total, base_admin + sum(acounts))
     self.logout()
     self.login_super()
     total = self.get_total_track_count()
     # should get the results from all samples
-    self.assertEqual(total, base_super + guest_count * (s1count + s2count))
+    self.assertEqual(total, base_super + guest_count * sum(scounts) + sum(acounts))
 
 
 class TestCountJsonDownload(CountingCase):
@@ -372,10 +394,7 @@ class TutorialPageCase(GahCase):
 
   def get_tutorial_page_grain_info(self, pk):
     r = self.client.get(reverse('tutorial_page', kwargs={'pk': pk}))
-    content = r.content.decode('utf-8')
-    grain_info_json = re.search(r"grain_info:\s*JSON.parse\('(.*)'\)", content).group(1)
-    grain_info_json = grain_info_json.replace("\\u0022", '"')
-    return json.loads(grain_info_json)
+    return grain_info_from_response(r)
 
   def test_adding_count_does_not_change_tutorial(self):
     self.login_counter()
@@ -483,7 +502,7 @@ class PublicPageCase(GahCase):
       reverse('public_sample', kwargs={ 'sample': 1, 'grain': 1 })
     )
     self.assertEqual(r.status_code, 200)
-    j = self.get_grain_info(r)
+    j = grain_info_from_response(r)
     latlngs = j['marker_latlngs']
     # There are three points; one is outside the ROI, one is in the hole
     self.assertEqual(len(latlngs), 1)
@@ -493,17 +512,11 @@ class PublicPageCase(GahCase):
       reverse('public_sample', kwargs={ 'sample': 1, 'grain': 1 })
     )
     self.assertEqual(r.status_code, 200)
-    j = self.get_grain_info(r)
+    j = grain_info_from_response(r)
     latlngs = j['marker_latlngs']
     # Now we should see them all
     self.assertEqual(len(latlngs), 3)
 
-  def get_grain_info(self, response):
-      content = response.content.decode('utf-8')
-      grain_info_json = re.search(r"grain_info:\s*JSON.parse\('(.*)'\)", content).group(1)
-      grain_info_json = grain_info_json.replace("\\u0022", '"')
-      j = json.loads(grain_info_json)
-      return j
 
 class GroupsTestCaseBase(GahCase):
   fixtures = [

--- a/ftc/test_selenium.py
+++ b/ftc/test_selenium.py
@@ -50,7 +50,7 @@ class BasePage:
 
     def fill_form(self, fields):
         for k,v in fields.items():
-            elt = self.driver.find_element(By.CSS_SELECTOR,  '*[name="{0}"]'.format(k))
+            elt = self.find_by_css(f'*[name="{k}"]')
             if v is None:
                 pass
             elif type(v) is bool:
@@ -70,14 +70,14 @@ class BasePage:
 
     def submit(self, until_fn=None):
         url = self.driver.current_url
-        self.driver.find_element(By.CSS_SELECTOR,  'input[type="submit"]').click()
+        self.click_by_css('input[type="submit"]')
         if until_fn is None:
             until_fn = lambda d: d.current_url != url
-        WebDriverWait(self.driver, timeout=2).until(until_fn)
+        self.wait_until(until_fn)
 
     def element_is_disabled(self, elt):
         if type(elt) is str:
-            elt = self.driver.find_element(By.ID, elt)
+            elt = self.find_by_id(elt)
         return 'leaflet-disabled' in elt.get_attribute('class').split(' ')
 
     def scroll_into_view(self, elt):
@@ -90,21 +90,19 @@ class BasePage:
         self.driver.execute_script(js)
 
     def find_by_id(self, id):
-        return WebDriverWait(self.driver, timeout=2).until(
+        return self.wait_until(
             lambda d: d.find_element(By.ID, id)
         )
 
     def find_by_css(self, css):
-        return WebDriverWait(self.driver, timeout=2).until(
+        return self.wait_until(
             lambda d: d.find_element(By.CSS_SELECTOR, css)
         )
 
     def find_by_xpath(self, xpath, timeout=3):
-        return WebDriverWait(
-            self.driver,
-            timeout=timeout
-        ).until(
-            lambda d: d.find_element(By.XPATH, xpath)
+        return self.wait_until(
+            lambda d: d.find_element(By.XPATH, xpath),
+            timeout=timeout,
         )
 
     def wait_until(self, fn, timeout=2):
@@ -183,7 +181,7 @@ class HomePage(BasePage):
         return 0 < len(es)
 
     def join(self):
-        self.driver.find_element(By.CSS_SELECTOR,  "a.btn-success").click()
+        self.click_by_css("a.btn-success")
         return JoinPage(self.driver, self.url)
 
     def become_guest(self):
@@ -217,7 +215,7 @@ class JoinPage(BasePage):
 class VerifyPage(BasePage):
     def check(self, user):
         self.wait_until(lambda _: "Verify" in self.driver.title)
-        info = self.driver.find_element(By.CSS_SELECTOR,  "div.alert-info")
+        info = self.find_by_css("div.alert-info")
         self.wait_until(lambda _: user.email in info.text)
         return self
 
@@ -237,12 +235,12 @@ class ConfirmPage(BasePage):
         return self
 
     def check(self, user):
-        assert user.identity in self.driver.find_element(By.CSS_SELECTOR,  "p.lead span.lead").text
-        assert user.email in self.driver.find_element(By.CSS_SELECTOR,  "p.lead > a").text
+        assert user.identity in self.find_by_css("p.lead span.lead").text
+        assert user.email in self.find_by_css("p.lead > a").text
         return self
 
     def confirm(self):
-        self.driver.find_element(By.CSS_SELECTOR,  "button.btn-success").click()
+        self.click_by_css("button.btn-success")
         return SignInPage(self.driver, self.url)
 
 
@@ -256,21 +254,15 @@ class SignInPage(BasePage):
         return self
 
     def sign_in(self, user):
-        self.driver.find_element(
-            By.CSS_SELECTOR,
-            'input[name="login"]'
-        ).send_keys(user.identity)
-        self.driver.find_element(
-            By.CSS_SELECTOR,
-            'input[name="password"]'
-        ).send_keys(user.password)
-        self.driver.find_element(By.CLASS_NAME, "btn-primary").click()
+        self.find_by_css('input[name="login"]').send_keys(user.identity)
+        self.find_by_css('input[name="password"]').send_keys(user.password)
+        self.click_by_css('.btn-primary')
         return ProfilePage(self.driver, self.url)
 
 
 class TutorialPage(BasePage):
     def check_text_contains(self, text):
-        tut_text = self.driver.find_element(By.ID, 'description').text
+        tut_text = self.find_by_id('description').text
         assert text in tut_text
         return self
 
@@ -332,7 +324,7 @@ class TutorialPage(BasePage):
 
 class ProfilePage(BasePage):
     def login_name(self):
-        return self.driver.find_element(By.CLASS_NAME, 'fa-user').text
+        return self.find_by_css('.fa-user').text
 
     def logout(self):
         self.click_by_id('logout-button')
@@ -484,7 +476,7 @@ class CountingPage(GrainViewPage):
         return self.assert_id_is(id)
 
     def try_click_at(self, x, y):
-        mp = self.driver.find_element(By.ID, "map")
+        mp = self.find_by_id("map")
         lil = mp.find_element(By.CSS_SELECTOR,  'img.leaflet-image-layer')
         actions = ActionChains(self.driver)
         actions.move_to_element_with_offset(lil,
@@ -510,7 +502,7 @@ class CountingPage(GrainViewPage):
         actions.click().pause(1.05)
         actions.move_to_element_with_offset(lil, (maxx - 0.5) * w, (maxy - 0.5) * h)
         actions.click().pause(0.1).perform()
-        self.driver.find_element(By.ID, "ftc-btn-delete").click()
+        self.click_by_id("ftc-btn-delete")
         return self
 
     def drag(self, marker, dx, dy):
@@ -566,9 +558,9 @@ class CountingPage(GrainViewPage):
         return GrainPage(self.driver, self.url)
 
     def drag_layer_handle(self, offset):
-        track = self.driver.find_element(By.ID, "focus-slider")
+        track = self.find_by_id("focus-slider")
         dy = offset * track.size['height']
-        handle = self.driver.find_element(By.CLASS_NAME, "noUi-touch-area")
+        handle = self.find_by_css(".noUi-touch-area")
         actions = ActionChains(self.driver)
         actions.drag_and_drop_by_offset(handle, 0, dy).pause(1.0).perform()
         return self
@@ -807,8 +799,8 @@ class SampleEditPage(BasePage):
 
 class GrainDetailPage(BasePage):
     def check(self):
-        self.driver.find_element(By.CSS_SELECTOR, 'table#image-list')
-        self.driver.find_element(By.ID, 'id_uploads')
+        self.find_by_css('table#image-list')
+        self.find_by_id('id_uploads')
         return self
 
     def go_zstack(self):
@@ -823,7 +815,7 @@ class GrainDetailPage(BasePage):
         return ImagePage(self.driver, self.url)
 
     def get_grain_index(self):
-        title = self.driver.find_element(By.ID, "title").text
+        title = self.find_by_id("title").text
         m = re.search(r'Grain (\d+) ', title)
         if m is None:
             return None
@@ -854,7 +846,7 @@ class GrainDetailPage(BasePage):
         return images
 
     def get_pair_element_text(self, id, sep=','):
-        t = self.driver.find_element(By.ID, id).text
+        t = self.find_by_id(id).text
         return t.split(sep)
 
     def get_size_element_text(self, id):
@@ -1097,7 +1089,7 @@ class GrainPage(BasePage):
         )
 
     def drag_marker(self, from_x_approx, from_y_approx, to_x, to_y):
-        img = self.driver.find_element(By.CSS_SELECTOR, 'img.leaflet-image-layer')
+        img = self.find_by_css('img.leaflet-image-layer')
         rect = img.rect
         markers = self.marker_elements()
         marker = find_best(markers, lambda m: sum_squares(
@@ -1112,7 +1104,7 @@ class GrainPage(BasePage):
         return self
 
     def drag_mid_marker(self, from_x_approx, from_y_approx, to_x, to_y):
-        img = self.driver.find_element(By.CSS_SELECTOR, 'img.leaflet-image-layer')
+        img = self.find_by_css('img.leaflet-image-layer')
         rect = img.rect
         markers = self.mid_marker_elements()
         marker = find_best(markers, lambda m: sum_squares(
@@ -1265,7 +1257,7 @@ class SeleniumTests(LiveServerTestCase):
                 print("failed to save screenshot")
         self.driver.close()
         if self.tmp is not None:
-            os.rmdir(self.tmp)
+            shutil.rmtree(self.tmp)
 
     def assertDictContainsSubset(self, a, b):
         self.assertEqual(b, {**b, **a})

--- a/templates/429.html
+++ b/templates/429.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<h2>{% translate 'Too Many Requests' %}</h2>
+<h2 data-error="429">{% translate 'Too Many Requests' %}</h2>
 
 <p>{% translate 'Please make requests slower!' %}</p>
 


### PR DESCRIPTION
Previously the guest would only see grains that had no guest count.
The test did not protect against this.
The test has been corrected, and now guests will be shown a random grain from the highest priority projects and samples. Is this what we want?